### PR TITLE
fix: export missing types and interfaces for public API

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,10 @@
   "name": "@corespeed/zypher",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "exports": "./src/mod.ts",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./tools": "./src/tools/mod.ts"
+  },
   "tasks": {
     "start": "deno run -A bin/cli.ts",
     "compile": "deno compile --allow-all --frozen=true --output dist/cli bin/cli.ts",

--- a/src/mcp/mod.ts
+++ b/src/mcp/mod.ts
@@ -1,0 +1,12 @@
+export * from "./McpClient.ts";
+export * from "./McpServerManager.ts";
+
+export * from "./types/index.ts";
+
+export * from "./auth/config.ts";
+export * from "./auth/McpOAuthClientProvider.ts";
+export * from "./auth/redirectCapture.ts";
+
+export * from "./utils/config.ts";
+export * from "./utils/transport.ts";
+export * from "./utils/zod.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,39 +1,16 @@
 // Public entry point for Zypher Agent SDK
-// Re-export core classes, types, and helpers that consumers should rely on.
 
 // Core agent
-export { TaskConcurrencyError, ZypherAgent } from "./ZypherAgent.ts";
-export type { ToolApprovalHandler, ZypherAgentConfig } from "./ZypherAgent.ts";
+export * from "./ZypherAgent.ts";
+export * from "./checkpoints.ts";
+export * from "./cli.ts";
+export * from "./error.ts";
+export * from "./message.ts";
+export * from "./prompt.ts";
 
-// MCP server management
-export { McpServerManager } from "./mcp/McpServerManager.ts";
-export type { ZypherMcpServer } from "./mcp/types/local.ts";
-export type { OAuthProviderOptions } from "./mcp/types/auth.ts";
-
-// Messaging primitives
-export { isFileAttachment, isMessage, printMessage } from "./message.ts";
-export type { ContentBlock, FileAttachment, Message } from "./message.ts";
-
-// Storage service interfaces
-export type {
-  AttachmentMetadata,
-  GenerateUploadUrlResult,
-  StorageService,
-  UploadOptions,
-  UploadResult,
-} from "./storage/StorageService.ts";
-export {
-  type S3Options,
-  S3StorageService,
-} from "./storage/S3StorageService.ts";
-export { FileNotFoundError, StorageError } from "./storage/StorageErrors.ts";
-
-// Tooling helpers
-export type { BaseParams, Tool } from "./tools/mod.ts";
-export { createTool, defineTool } from "./tools/mod.ts";
-
-// Error utilities
-export { AbortError, formatError, isAbortError } from "./error.ts";
-
-// CLI
-export { runAgentInTerminal } from "./cli.ts";
+// Modules
+export * from "./errorDetection/mod.ts";
+export * from "./llm/mod.ts";
+export * from "./mcp/mod.ts";
+export * from "./storage/mod.ts";
+export * from "./utils/mod.ts";


### PR DESCRIPTION
- Add tools export path in deno.json
- Create mcp/mod.ts to export all MCP types
- Use wildcard exports in mod.ts to ensure complete type coverage