### PR TITLE
refactor: remove CREATE from EditFileTools

### DIFF
--- a/src/tools/EditFileTool.ts
+++ b/src/tools/EditFileTool.ts
@@ -435,7 +435,7 @@ On error:
                 data: { targetFile, action: EditFileAction.REPLACE_STR_FIRST },
               });
             }
-            
+
             return await replaceStringInFile(
               targetFile,
               oldContent,
@@ -454,7 +454,7 @@ On error:
                 data: { targetFile, action: EditFileAction.REPLACE_STR_ALL },
               });
             }
-            
+
             return await replaceStringInFile(
               targetFile,
               oldContent,


### PR DESCRIPTION
The LLM may incorrectly choose create empty file to save files. Since this action can be replaced by overwrite, the create operation has been removed.