### PR TITLE
refactor: simplify ZypherAgent constructor with optional services and reasonable defaults

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,14 +1,5 @@
 import "@std/dotenv/load";
-import {
-  formatError,
-  McpServerManager,
-  runAgentInTerminal,
-  ZypherAgent,
-} from "@zypher/mod.ts";
-import {
-  LoopInterceptorManager,
-  ToolExecutionInterceptor,
-} from "@zypher/loopInterceptors/mod.ts";
+import { formatError, runAgentInTerminal, ZypherAgent } from "@zypher/mod.ts";
 import {
   CopyFileTool,
   defineEditFileTool,
@@ -55,8 +46,6 @@ const { options: cli } = await new Command()
   )
   .option("--backup-dir <backupDir:string>", "Directory to store backups")
   .parse(Deno.args);
-
-const mcpServerManager = new McpServerManager();
 
 function inferProvider(
   provider?: string,
@@ -118,18 +107,14 @@ async function main(): Promise<void> {
         baseUrl: cli.baseUrl,
       });
 
-    // Create interceptor manager with default interceptors for CLI
-    const loopInterceptorManager = new LoopInterceptorManager();
-    loopInterceptorManager.register(
-      new ToolExecutionInterceptor(mcpServerManager),
-    );
-
     const agent = new ZypherAgent(
       providerInstance,
-      mcpServerManager,
-      loopInterceptorManager,
-      { userId: cli.userId },
+      {
+        userId: cli.userId,
+      },
     );
+
+    const mcpServerManager = agent.mcpServerManager;
 
     // Register all available tools
     mcpServerManager.registerTool(ReadFileTool);

--- a/src/ZypherAgent.ts
+++ b/src/ZypherAgent.ts
@@ -12,7 +12,7 @@ import {
   getCheckpointDetails,
 } from "./checkpoints.ts";
 import type { ContentBlock, FileAttachment, Message } from "./message.ts";
-import type { McpServerManager } from "./mcp/McpServerManager.ts";
+import { McpServerManager } from "./mcp/McpServerManager.ts";
 import type { StorageService } from "./storage/StorageService.ts";
 import { Completer } from "./utils/mod.ts";
 import {
@@ -30,7 +30,9 @@ import {
 } from "./storage/mod.ts";
 import {
   LoopDecision,
-  type LoopInterceptorManager,
+  LoopInterceptorManager,
+  MaxTokensInterceptor,
+  ToolExecutionInterceptor,
 } from "./loopInterceptors/mod.ts";
 import * as path from "@std/path";
 
@@ -76,6 +78,15 @@ export interface TaskCancelledEvent {
 const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_MAX_ITERATIONS = 25;
 
+export interface ZypherAgentServices {
+  /** Custom MCP server manager. If not provided, a default instance will be created. */
+  mcpServerManager?: McpServerManager;
+  /** Custom loop interceptor manager. If not provided, a default instance will be created. */
+  loopInterceptorManager?: LoopInterceptorManager;
+  /** Storage service for file attachments */
+  storageService?: StorageService;
+}
+
 export interface ZypherAgentConfig {
   maxTokens?: number;
   /** Whether to load and save message history. Defaults to true. */
@@ -114,12 +125,20 @@ export class ZypherAgent {
   #isTaskRunning: boolean = false;
   #taskCompleter: Completer<void> | null = null;
 
+  /**
+   * Creates a new ZypherAgent instance
+   *
+   * @param modelProvider The AI model provider to use for chat completions
+   * @param config Configuration options for the agent's behavior
+   * @param services External services for the agent. The agent takes ownership of all provided services:
+   *   - mcpServerManager: Creates default instance if not provided
+   *   - loopInterceptorManager: Creates default with ToolExecutionInterceptor and MaxTokensInterceptor if not provided
+   *   - storageService: Optional, no default created - only used if explicitly provided
+   */
   constructor(
     modelProvider: ModelProvider,
-    mcpServerManager: McpServerManager,
-    loopInterceptorManager: LoopInterceptorManager,
     config: ZypherAgentConfig = {},
-    storageService?: StorageService,
+    services: ZypherAgentServices = {},
   ) {
     const userId = config.userId ?? Deno.env.get("ZYPHER_USER_ID");
 
@@ -130,12 +149,19 @@ export class ZypherAgent {
     this.#persistHistory = config.persistHistory ?? true;
     this.#enableCheckpointing = config.enableCheckpointing ?? true;
     this.#userId = userId;
-    this.#mcpServerManager = mcpServerManager;
-    this.#loopInterceptorManager = loopInterceptorManager;
-    this.#storageService = storageService;
+
     // Default timeout is 15 minutes, 0 = disabled
     this.#taskTimeoutMs = config.taskTimeoutMs ?? 900000;
     this.#customInstructions = config.customInstructions;
+
+    this.#mcpServerManager = services.mcpServerManager ??
+      new McpServerManager();
+    this.#loopInterceptorManager = services.loopInterceptorManager ??
+      new LoopInterceptorManager([
+        new ToolExecutionInterceptor(this.#mcpServerManager),
+        new MaxTokensInterceptor(),
+      ]);
+    this.#storageService = services.storageService;
   }
 
   async init(): Promise<void> {
@@ -187,6 +213,20 @@ export class ZypherAgent {
    */
   get isTaskRunning(): boolean {
     return this.#isTaskRunning;
+  }
+
+  /**
+   * Get the MCP server manager for configuration
+   */
+  get mcpServerManager(): McpServerManager {
+    return this.#mcpServerManager;
+  }
+
+  /**
+   * Get the loop interceptor manager for configuration
+   */
+  get loopInterceptorManager(): LoopInterceptorManager {
+    return this.#loopInterceptorManager;
   }
 
   /**

--- a/src/loopInterceptors/LoopInterceptorManager.ts
+++ b/src/loopInterceptors/LoopInterceptorManager.ts
@@ -10,7 +10,15 @@ import { AbortError, formatError } from "../error.ts";
  * Manages and executes loop interceptors
  */
 export class LoopInterceptorManager {
-  private interceptors: LoopInterceptor[] = [];
+  #interceptors: LoopInterceptor[];
+
+  /**
+   * Creates a new LoopInterceptorManager
+   * @param initialInterceptors Optional array of interceptors to register immediately
+   */
+  constructor(initialInterceptors: LoopInterceptor[] = []) {
+    this.#interceptors = [...initialInterceptors];
+  }
 
   /**
    * Register a new loop interceptor
@@ -18,13 +26,13 @@ export class LoopInterceptorManager {
    */
   register(interceptor: LoopInterceptor): void {
     // Check for name conflicts
-    if (this.interceptors.some((i) => i.name === interceptor.name)) {
+    if (this.#interceptors.some((i) => i.name === interceptor.name)) {
       throw new Error(
         `Loop interceptor with name '${interceptor.name}' is already registered`,
       );
     }
 
-    this.interceptors.push(interceptor);
+    this.#interceptors.push(interceptor);
   }
 
   /**
@@ -33,9 +41,9 @@ export class LoopInterceptorManager {
    * @returns boolean True if interceptor was found and removed
    */
   unregister(name: string): boolean {
-    const index = this.interceptors.findIndex((i) => i.name === name);
+    const index = this.#interceptors.findIndex((i) => i.name === name);
     if (index >= 0) {
-      this.interceptors.splice(index, 1);
+      this.#interceptors.splice(index, 1);
       return true;
     }
     return false;
@@ -46,7 +54,7 @@ export class LoopInterceptorManager {
    * @returns string[] Array of interceptor names
    */
   getRegisteredNames(): string[] {
-    return this.interceptors.map((i) => i.name);
+    return this.#interceptors.map((i) => i.name);
   }
 
   /**
@@ -58,7 +66,7 @@ export class LoopInterceptorManager {
     context: InterceptorContext,
   ): Promise<InterceptorResult> {
     // Execute interceptors sequentially until one decides to CONTINUE
-    for (const interceptor of this.interceptors) {
+    for (const interceptor of this.#interceptors) {
       // Check for abort signal
       if (context.signal?.aborted) {
         throw new AbortError("Aborted while running loop interceptors");
@@ -96,7 +104,7 @@ export class LoopInterceptorManager {
    * Clear all registered interceptors
    */
   clear(): void {
-    this.interceptors = [];
+    this.#interceptors = [];
   }
 
   /**
@@ -104,6 +112,6 @@ export class LoopInterceptorManager {
    * @returns number Count of registered interceptors
    */
   count(): number {
-    return this.interceptors.length;
+    return this.#interceptors.length;
   }
 }


### PR DESCRIPTION
- Move from 5 required parameters to 1 required + 2 optional
- Auto-create MCP manager and interceptors with defaults
- Add constructor parameter to LoopInterceptorManager for initial interceptors