### PR TITLE
feat: add automated JSR publishing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.4.3
+          deno-version: v2.5.1
 
       - name: Install dependencies
         run: deno install --frozen=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,94 @@
+name: Publish to JSR
+
+on:
+  push:
+    branches: [main]
+    paths: ['deno.json']
+
+permissions:
+  contents: read
+  id-token: write # The OIDC ID token is used for authentication with JSR.
+
+jobs:
+  check-version-change:
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.check.outputs.changed }}
+      new-version: ${{ steps.check.outputs.new-version }}
+      old-version: ${{ steps.check.outputs.old-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need previous commit
+
+      - name: Check version change
+        id: check
+        run: |
+          NEW_VERSION=$(jq -r '.version' deno.json)
+          OLD_VERSION=$(git show HEAD~1:deno.json | jq -r '.version' 2>/dev/null || echo "0.0.0")
+
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "old-version=$OLD_VERSION" >> $GITHUB_OUTPUT
+            echo "🚀 Version change detected: $OLD_VERSION → $NEW_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No version change in deno.json"
+          fi
+
+  publish:
+    needs: check-version-change
+    if: needs.check-version-change.outputs.version-changed == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for changelog
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.5.1
+
+      - name: Install dependencies
+        run: deno install --frozen=true
+
+      - name: Run validation
+        run: |
+          echo "🔍 Validating v${{ needs.check-version-change.outputs.new-version }}..."
+          deno fmt --check
+          deno lint
+          deno check .
+          deno test --ignore=**/*.integration.test.ts
+
+      - name: Generate changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+
+      - name: Dry run publish
+        run: |
+          echo "🧪 Testing JSR publish..."
+          deno publish --dry-run
+
+      - name: Publish to JSR
+        run: |
+          echo "📦 Publishing v${{ needs.check-version-change.outputs.new-version }} to JSR..."
+          deno publish
+          echo "✅ Successfully published!"
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ needs.check-version-change.outputs.new-version }}
+          release_name: Release v${{ needs.check-version-change.outputs.new-version }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
+
+            ---
+            📦 **JSR Package**: https://jsr.io/@corespeed/zypher/v${{ needs.check-version-change.outputs.new-version }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,15 +38,46 @@ jobs:
             echo "No version change in deno.json"
           fi
 
-  publish:
+  generate-changelog:
     needs: check-version-change
     if: needs.check-version-change.outputs.version-changed == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      changelog: ${{ steps.changelog.outputs.changelog }}
+      has-previous-tag: ${{ steps.check-tag.outputs.has-previous-tag }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need full history for changelog
+
+      - name: Check for previous version tag
+        id: check-tag
+        run: |
+          PREVIOUS_TAG=$(git tag --list --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "previous-tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+            echo "has-previous-tag=true" >> $GITHUB_OUTPUT
+            echo "Found previous tag: $PREVIOUS_TAG"
+          else
+            echo "has-previous-tag=false" >> $GITHUB_OUTPUT
+            echo "No previous version tags found - skipping changelog generation"
+          fi
+
+      - name: Generate changelog
+        id: changelog
+        if: steps.check-tag.outputs.has-previous-tag == 'true'
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          fromTag: ${{ steps.check-tag.outputs.previous-tag }}
+
+  publish:
+    needs: [check-version-change, generate-changelog]
+    if: needs.check-version-change.outputs.version-changed == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -63,17 +94,6 @@ jobs:
           deno lint
           deno check .
           deno test --ignore=**/*.integration.test.ts
-
-      - name: Generate changelog
-        id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Dry run publish
-        run: |
-          echo "🧪 Testing JSR publish..."
-          deno publish --dry-run
 
       - name: Publish to JSR
         run: |
@@ -94,7 +114,7 @@ jobs:
           tag_name: v${{ needs.check-version-change.outputs.new-version }}
           release_name: Release v${{ needs.check-version-change.outputs.new-version }}
           body: |
-            ${{ steps.changelog.outputs.changelog }}
+            ${{ needs.generate-changelog.outputs.changelog || format('Release v{0}', needs.check-version-change.outputs.new-version) }}
 
             ---
             📦 **JSR Package**: https://jsr.io/@corespeed/zypher/v${{ needs.check-version-change.outputs.new-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, ci/add-jsr-publish-workflow] # Add test branch
     paths: ["deno.json"]
-  workflow_dispatch:  # Allow manual trigger for failed publishes
+  workflow_dispatch: # Allow manual trigger for failed publishes
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: # Allow manual trigger for failed publishes
 
 permissions:
-  contents: read
+  contents: write # Required for creating GitHub releases
   id-token: write # The OIDC ID token is used for authentication with JSR.
 
 jobs:
@@ -64,23 +64,12 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        continue-on-error: true
         uses: mikepenz/release-changelog-builder-action@v5
-
-      - name: Publish to JSR
-        run: |
-          echo "📦 Publishing v${{ needs.check-version-change.outputs.new-version }} to JSR..."
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            deno publish
-            echo "✅ Successfully published!"
-          else
-            echo "🧪 Test mode - skipping actual publish (not on main branch)"
-          fi
 
       - name: Create GitHub Release
         if: github.ref == 'refs/heads/main' # Only create release on main
         uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ needs.check-version-change.outputs.new-version }}
           release_name: Release v${{ needs.check-version-change.outputs.new-version }}
@@ -91,3 +80,13 @@ jobs:
             📦 **JSR Package**: https://jsr.io/@corespeed/zypher/v${{ needs.check-version-change.outputs.new-version }}
           draft: false
           prerelease: false
+
+      - name: Publish to JSR
+        run: |
+          echo "📦 Publishing v${{ needs.check-version-change.outputs.new-version }} to JSR..."
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            deno publish
+            echo "✅ Successfully published!"
+          else
+            echo "🧪 Test mode - skipping actual publish (not on main branch)"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,6 @@ on:
     branches: [main, ci/add-jsr-publish-workflow] # Add test branch
     paths: ["deno.json"]
 
-permissions:
-  contents: write # Required for creating GitHub releases
-  id-token: write # The OIDC ID token is used for authentication with JSR.
-
 jobs:
   check-version-change:
     runs-on: ubuntu-latest
@@ -41,6 +37,9 @@ jobs:
     needs: [check-version-change]
     if: needs.check-version-change.outputs.version-changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required for creating GitHub releases
+      id-token: write # Required for JSR authentication
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to JSR
 
 on:
   push:
-    branches: [main, ci/add-jsr-publish-workflow] # Add test branch
+    branches: [main]
     paths: ["deno.json"]
 
 jobs:
@@ -66,7 +66,6 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v5
 
       - name: Create GitHub Release
-        if: github.ref == 'refs/heads/main' # Only create release on main
         uses: actions/create-release@v1
         with:
           tag_name: v${{ needs.check-version-change.outputs.new-version }}
@@ -82,9 +81,5 @@ jobs:
       - name: Publish to JSR
         run: |
           echo "📦 Publishing v${{ needs.check-version-change.outputs.new-version }} to JSR..."
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            deno publish
-            echo "✅ Successfully published!"
-          else
-            echo "🧪 Test mode - skipping actual publish (not on main branch)"
-          fi
+          deno publish
+          echo "✅ Successfully published!"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, ci/add-jsr-publish-workflow] # Add test branch
     paths: ["deno.json"]
+  workflow_dispatch:  # Allow manual trigger for failed publishes
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Generate changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Dry run publish
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to JSR
 on:
   push:
     branches: [main]
-    paths: ['deno.json']
+    paths: ["deno.json"]
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2  # Only need previous commit
+          fetch-depth: 2 # Only need previous commit
 
       - name: Check version change
         id: check
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Need full history for changelog
+          fetch-depth: 0 # Need full history for changelog
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to JSR
 
 on:
   push:
-    branches: [main]
+    branches: [main, ci/add-jsr-publish-workflow]  # Add test branch
     paths: ["deno.json"]
 
 permissions:
@@ -75,10 +75,15 @@ jobs:
       - name: Publish to JSR
         run: |
           echo "📦 Publishing v${{ needs.check-version-change.outputs.new-version }} to JSR..."
-          deno publish
-          echo "✅ Successfully published!"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            deno publish
+            echo "✅ Successfully published!"
+          else
+            echo "🧪 Test mode - skipping actual publish (not on main branch)"
+          fi
 
       - name: Create GitHub Release
+        if: github.ref == 'refs/heads/main'  # Only create release on main
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,41 +38,8 @@ jobs:
             echo "No version change in deno.json"
           fi
 
-  generate-changelog:
-    needs: check-version-change
-    if: needs.check-version-change.outputs.version-changed == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      changelog: ${{ steps.changelog.outputs.changelog }}
-      has-previous-tag: ${{ steps.check-tag.outputs.has-previous-tag }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Need full history for changelog
-
-      - name: Check for previous version tag
-        id: check-tag
-        run: |
-          PREVIOUS_TAG=$(git tag --list --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-          if [ -n "$PREVIOUS_TAG" ]; then
-            echo "previous-tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
-            echo "has-previous-tag=true" >> $GITHUB_OUTPUT
-            echo "Found previous tag: $PREVIOUS_TAG"
-          else
-            echo "has-previous-tag=false" >> $GITHUB_OUTPUT
-            echo "No previous version tags found - skipping changelog generation"
-          fi
-
-      - name: Generate changelog
-        id: changelog
-        if: steps.check-tag.outputs.has-previous-tag == 'true'
-        uses: mikepenz/release-changelog-builder-action@v5
-        with:
-          fromTag: ${{ steps.check-tag.outputs.previous-tag }}
-
   publish:
-    needs: [check-version-change, generate-changelog]
+    needs: [check-version-change]
     if: needs.check-version-change.outputs.version-changed == 'true'
     runs-on: ubuntu-latest
 
@@ -95,6 +62,10 @@ jobs:
           deno check .
           deno test --ignore=**/*.integration.test.ts
 
+      - name: Generate changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+
       - name: Publish to JSR
         run: |
           echo "📦 Publishing v${{ needs.check-version-change.outputs.new-version }} to JSR..."
@@ -114,7 +85,7 @@ jobs:
           tag_name: v${{ needs.check-version-change.outputs.new-version }}
           release_name: Release v${{ needs.check-version-change.outputs.new-version }}
           body: |
-            ${{ needs.generate-changelog.outputs.changelog || format('Release v{0}', needs.check-version-change.outputs.new-version) }}
+            ${{ steps.changelog.outputs.changelog || format('Release v{0}', needs.check-version-change.outputs.new-version) }}
 
             ---
             📦 **JSR Package**: https://jsr.io/@corespeed/zypher/v${{ needs.check-version-change.outputs.new-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, ci/add-jsr-publish-workflow] # Add test branch
     paths: ["deno.json"]
-  workflow_dispatch: # Allow manual trigger for failed publishes
 
 permissions:
   contents: write # Required for creating GitHub releases

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to JSR
 
 on:
   push:
-    branches: [main, ci/add-jsr-publish-workflow]  # Add test branch
+    branches: [main, ci/add-jsr-publish-workflow] # Add test branch
     paths: ["deno.json"]
 
 permissions:
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        if: github.ref == 'refs/heads/main'  # Only create release on main
+        if: github.ref == 'refs/heads/main' # Only create release on main
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
             ---
             📦 **JSR Package**: https://jsr.io/@corespeed/zypher/v${{ needs.check-version-change.outputs.new-version }}
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(needs.check-version-change.outputs.new-version, '-') }}
 
       - name: Publish to JSR
         run: |

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.0",
+  "version": "0.2.1-test",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.3-test",
+  "version": "0.2.4-test",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.4-test",
+  "version": "0.2.5",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.2-test",
+  "version": "0.2.3-test",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.2.1-test",
+  "version": "0.2.2-test",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
This pull requests add JSR publishing GitHub Actions workflow that:
- Triggers on version changes in deno.json
- Validates code before publishing (lint, type check, tests)
- Generates changelog with release-changelog-builder
- Publishes to JSR using OIDC authentication
- Creates GitHub release with generated changelog
- Uses Deno v2.5.1 in publish workflow

In addition, this pull request also bump the Deno version in build workflow to 2.5.1