### PR TITLE
fix(mcp): pass custom headers to remote MCP server connections

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/mcp/connect.ts
+++ b/src/mcp/connect.ts
@@ -134,6 +134,9 @@ export async function connectToRemoteServer(
         new StreamableHTTPClientTransport(
           mcpServerUrl,
           {
+            requestInit: {
+              headers: remoteConfig.headers,
+            },
             authProvider: options?.oauth?.authProvider,
           },
         ),
@@ -153,6 +156,9 @@ export async function connectToRemoteServer(
           new SSEClientTransport(
             mcpServerUrl,
             {
+              requestInit: {
+                headers: remoteConfig.headers,
+              },
               authProvider: options?.oauth?.authProvider,
             },
           ),


### PR DESCRIPTION
This pull request:
- Adds missing `requestInit` configuration to pass custom headers through both `StreamableHTTPClientTransport` and `SSEClientTransport` for remote MCP server connections.
- Bumps version to 0.3.2