### PR TITLE
fix(ci): changelog generation in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,13 @@ jobs:
           deno check .
           deno test --ignore=**/*.integration.test.ts
 
+      - name: Create Git Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a v${{ needs.check-version-change.outputs.new-version }} -m "Release v${{ needs.check-version-change.outputs.new-version }}"
+          git push origin "refs/tags/v${{ needs.check-version-change.outputs.new-version }}"
+
       - name: Generate changelog
         id: changelog
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Add full git history fetch for changelog generation
- Create git tag before running changelog action (the action requires the tag to exist to generate correct changelog between releases)
- Add GITHUB_TOKEN for GitHub API access to fetch tag and release history

## Changes
- Set `fetch-depth: 0` in checkout action to ensure full git history is available
- Add new step to create and push git tag before changelog generation, since the changelog action needs the tag to already exist
- Add `GITHUB_TOKEN` environment variable to changelog generation step so it can access GitHub API to fetch tags and releases