### PR TITLE
fix: add --allow-env to deno test in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,12 +55,14 @@ jobs:
         run: deno install --frozen=true
 
       - name: Run validation
+        # --allow-env required in unit tests for MCP SDK transitive dependencies
+        # (cross-spawn/which reads OSTYPE at module load)
         run: |
           echo "🔍 Validating v${{ needs.check-version-change.outputs.new-version }}..."
           deno fmt --check
           deno lint
           deno check .
-          deno test --ignore=**/*.integration.test.ts
+          deno test --allow-env --ignore=**/*.integration.test.ts
 
       - name: Create Git Tag
         run: |

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@corespeed/zypher",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
MCP SDK's transitive dependency (cross-spawn/which) reads OSTYPE environment variable at module load, causing tests to fail without this permission