### PR TITLE
fix: call publish workflow directly from release to bypass GITHUB_TOKEN limitation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,3 +106,4 @@ jobs:
       packages: ${{ needs.detect-changes.outputs.packages }}
     permissions:
       contents: write
+      id-token: write # Required for publish.yml to authenticate with JSR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,19 @@
+# Publish packages to JSR
+#
+# Triggers:
+# - release: [published] - For manually created GitHub releases
+# - workflow_call - Called by release.yml after automated releases
+#   (GitHub doesn't trigger workflows from events created by GITHUB_TOKEN)
+# - workflow_dispatch - Manual trigger for testing
+#
+# See: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+
 name: Publish to JSR
 
 on:
   release:
     types: [published]
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,13 @@ jobs:
           prerelease: ${{ contains(matrix.package.version, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Call publish workflow directly because GitHub doesn't trigger workflows
+  # from events (like release creation) made with GITHUB_TOKEN.
+  # See: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: read
+      id-token: write # The OIDC ID token is used for authentication with JSR.


### PR DESCRIPTION
## Summary

Fix automated publishing to JSR after releases created by the release workflow.

GitHub Actions doesn't trigger workflows from events (like release creation) created with `GITHUB_TOKEN`. This means when `release.yml` creates a GitHub release, the `publish.yml` workflow (triggered on `release: [published]`) never runs.

This PR fixes the issue by:
- Adding `workflow_call` trigger to `publish.yml` so it can be called from other workflows
- Calling `publish.yml` directly from `release.yml` after creating the release
- Adding the required `id-token: write` permission for JSR OIDC authentication

Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

## Changes

- `.github/workflows/publish.yml`: Add `workflow_call` trigger and documentation
- `.github/workflows/release.yml`: Call publish workflow after release creation
- `.github/workflows/build.yml`: Add `id-token: write` permission
