### PR TITLE
fix: resolve styling glitches in Safari dark mode

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         />
       </head>
       <body className={cn("flex flex-col min-h-screen", inter.className)}>
-        <RootProvider>{children}</RootProvider>
+        <RootProvider theme={{ enabled: false }}>{children}</RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Fix style glitches when using Safari's dark mode

before:
<img width="1702" height="1188" alt="image" src="https://github.com/user-attachments/assets/168a6d6c-b368-47d7-a3a8-454a457513b4" />

after:
<img width="1182" height="1214" alt="image" src="https://github.com/user-attachments/assets/42789a94-bd52-4464-8e75-da9d6cd50085" />
