### PR TITLE
feat(http): add HTTP package for exposing Zypher Agent as HTTP API server

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,7 @@
     "packages/agui",
     "packages/cli",
     "packages/acp",
+    "packages/http",
     "examples/mcp",
     "examples/agui",
     "examples/ptc"

--- a/deno.lock
+++ b/deno.lock
@@ -6,6 +6,7 @@
     "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@corespeed/mcp-store-client@^1.9.0": "1.9.0",
+    "jsr:@hono/hono@4": "4.11.3",
     "jsr:@std/assert@^1.0.14": "1.0.16",
     "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
@@ -77,6 +78,9 @@
     },
     "@corespeed/mcp-store-client@1.9.0": {
       "integrity": "cc1ee0325df7e75040e078d8e157772d2386a7b4166c672d8e80a8b86bbc6b47"
+    },
+    "@hono/hono@4.11.3": {
+      "integrity": "de7f245516a970c60c6f4bf5b0f1585efbee38ee4e01171994c2b9d69d035d70"
     },
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
@@ -2086,6 +2090,16 @@
           "jsr:@std/dotenv@~0.225.5",
           "npm:chalk@^5.6.2",
           "npm:rxjs-for-await@1"
+        ]
+      },
+      "packages/http": {
+        "dependencies": [
+          "jsr:@cliffy/command@^1.0.0-rc.8",
+          "jsr:@hono/hono@4",
+          "jsr:@std/assert@^1.0.16",
+          "npm:rxjs-for-await@1",
+          "npm:rxjs@^7.8.2",
+          "npm:zod@^4.2.0"
         ]
       }
     }

--- a/packages/http/deno.json
+++ b/packages/http/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zypher/http",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
+    "@std/assert": "jsr:@std/assert@^1.0.16",
+    "hono": "jsr:@hono/hono@^4",
+    "rxjs": "npm:rxjs@^7.8.2",
+    "rxjs-for-await": "npm:rxjs-for-await@^1.0.0",
+    "zod": "npm:zod@^4.2.0"
+  }
+}

--- a/packages/http/main.ts
+++ b/packages/http/main.ts
@@ -1,0 +1,116 @@
+import {
+  AnthropicModelProvider,
+  createZypherAgent,
+  OpenAIModelProvider,
+} from "@zypher/agent";
+import {
+  createFileSystemTools,
+  createImageTools,
+  RunTerminalCmdTool,
+} from "@zypher/agent/tools";
+import { Command, EnumType } from "@cliffy/command";
+import { createZypherHandler } from "./mod.ts";
+
+const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_OPENAI_MODEL = "gpt-4o-2024-11-20";
+
+const providerType = new EnumType(["anthropic", "openai"]);
+
+function inferProvider(
+  provider?: string,
+  model?: string,
+): "anthropic" | "openai" {
+  const p = provider?.toLowerCase();
+  if (p === "openai" || p === "anthropic") return p;
+  if (!model) return "anthropic";
+  const m = model.toLowerCase();
+  if (
+    m.includes("claude") || m.startsWith("sonnet") || m.startsWith("haiku") ||
+    m.startsWith("opus")
+  ) {
+    return "anthropic";
+  }
+  return "openai";
+}
+
+export async function main(): Promise<void> {
+  const { options: cli } = await new Command()
+    .name("zypher-http")
+    .description("Zypher Agent HTTP Server")
+    .type("provider", providerType)
+    .option("-k, --api-key <apiKey:string>", "Model provider API key", {
+      required: true,
+    })
+    .option("-m, --model <model:string>", "Model name")
+    .option("-P, --provider <provider:provider>", "Model provider")
+    .option("-b, --base-url <baseUrl:string>", "Custom API base URL")
+    .option(
+      "-w, --workDir <workingDirectory:string>",
+      "Working directory for agent operations",
+    )
+    .option("-u, --user-id <userId:string>", "Custom user ID")
+    .option(
+      "--openai-api-key <openaiApiKey:string>",
+      "OpenAI API key for image tools when provider=anthropic",
+    )
+    .option("-p, --port <port:number>", "Port to listen on", {
+      default: 8080,
+    })
+    .option("--host <host:string>", "Host to bind to", {
+      default: "0.0.0.0",
+    })
+    .parse(Deno.args);
+
+  const selectedProvider = inferProvider(cli.provider, cli.model);
+  const modelToUse = cli.model ??
+    (selectedProvider === "openai"
+      ? DEFAULT_OPENAI_MODEL
+      : DEFAULT_ANTHROPIC_MODEL);
+
+  const providerInstance = selectedProvider === "openai"
+    ? new OpenAIModelProvider({
+      apiKey: cli.apiKey,
+      baseUrl: cli.baseUrl,
+    })
+    : new AnthropicModelProvider({
+      apiKey: cli.apiKey,
+      baseUrl: cli.baseUrl,
+    });
+
+  const openaiApiKey = cli.provider === "openai"
+    ? cli.apiKey
+    : cli.openaiApiKey;
+
+  const tools = [
+    ...createFileSystemTools(),
+    RunTerminalCmdTool,
+    ...(openaiApiKey ? createImageTools(openaiApiKey) : []),
+  ];
+
+  const agent = await createZypherAgent({
+    modelProvider: providerInstance,
+    workingDirectory: cli.workDir,
+    tools,
+    context: { userId: cli.userId },
+  });
+
+  const app = createZypherHandler({ agent });
+
+  Deno.serve({
+    port: cli.port,
+    hostname: cli.host,
+    onListen: ({ hostname, port }) => {
+      console.log(`Zypher HTTP server listening on http://${hostname}:${port}`);
+      console.log(`Provider: ${selectedProvider}`);
+      console.log(`Model: ${modelToUse}`);
+      if (cli.baseUrl) console.log(`Base URL: ${cli.baseUrl}`);
+      if (cli.workDir) console.log(`Working directory: ${cli.workDir}`);
+      if (cli.userId) console.log(`User ID: ${cli.userId}`);
+      console.log(`Tools: ${Array.from(agent.mcp.tools.keys()).join(", ")}`);
+    },
+  }, app.fetch);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/packages/http/mod.ts
+++ b/packages/http/mod.ts
@@ -1,0 +1,320 @@
+/**
+ * @zypher/http - Framework-agnostic HTTP handler for Zypher Agent
+ *
+ * Uses Hono internally, exports a standard web fetch handler that can be used
+ * with Deno.serve, Hono, or any Web-compatible framework.
+ *
+ * @example Run as standalone server
+ * ```bash
+ * deno run -A jsr:@zypher/http -k YOUR_API_KEY
+ * ```
+ *
+ * @example Import as library
+ * ```ts
+ * import { createZypherHandler } from "@zypher/http";
+ * import { createZypherAgent, AnthropicModelProvider } from "@zypher/agent";
+ *
+ * const agent = await createZypherAgent({
+ *   modelProvider: new AnthropicModelProvider({ apiKey: Deno.env.get("ANTHROPIC_API_KEY")! }),
+ * });
+ *
+ * const app = createZypherHandler({ agent });
+ *
+ * // Use with Deno.serve
+ * Deno.serve(app.fetch);
+ *
+ * // Or mount in another Hono app
+ * mainApp.route("/api/agent", app);
+ * ```
+ *
+ * ## REST Endpoints
+ *
+ * - `GET  /health`   - Health check, returns `{ status: "ok" }`
+ * - `GET  /messages` - Get agent message history
+ * - `DELETE /messages` - Clear agent message history
+ *
+ * ## WebSocket Endpoint
+ *
+ * - `GET /task/ws` - WebSocket connection for real-time task execution
+ *
+ * ### WebSocket Protocol (zypher.v1)
+ *
+ * Client messages:
+ * - `{ action: "startTask", task: string, model?: string }` - Start a new task
+ * - `{ action: "resumeTask", lastEventId?: string }` - Resume and replay events
+ * - `{ action: "cancelTask" }` - Cancel the running task
+ * - `{ action: "approveTool", approved: boolean }` - Approve/reject tool execution
+ *
+ * Server messages:
+ * - HttpTaskEvent objects with `eventId` for tracking
+ * - `{ type: "heartbeat", timestamp: number }` - Keep-alive (every 30s)
+ * - `{ type: "completed", timestamp: number }` - Task completed
+ * - `{ type: "error", error: string }` - Error occurred
+ *
+ * @module
+ */
+
+import { Hono } from "hono";
+import { upgradeWebSocket } from "hono/deno";
+import { sendServerMessage, wsClientMessageSchema } from "./schema.ts";
+import {
+  type HttpTaskEvent,
+  HttpTaskEventId,
+  replayHttpTaskEvents,
+  withHttpTaskEventReplayAndHeartbeat,
+} from "./task_event.ts";
+import { filter, map, type Observable, type ReplaySubject } from "rxjs";
+import type { Completer, ZypherAgent } from "@zypher/agent";
+
+export interface ZypherHandlerOptions {
+  agent: ZypherAgent;
+}
+
+/**
+ * Creates a Hono app that handles Zypher agent requests.
+ * The returned app can be used as a fetch handler or mounted in another Hono app.
+ */
+export function createZypherHandler(options: ZypherHandlerOptions): Hono {
+  const app = new Hono();
+  const { agent } = options;
+
+  let taskAbortController: AbortController | null = null;
+  let taskEventSubject: ReplaySubject<HttpTaskEvent> | null = null;
+  let toolApprovalCompletor: Completer<boolean> | null = null;
+  let serverLatestEventId: HttpTaskEventId | undefined;
+
+  // Health check
+  app.get("/health", (c) => c.json({ status: "ok" }));
+
+  // Get agent messages
+  app.get("/messages", (c) => {
+    return c.json(agent.messages);
+  });
+
+  // Clear agent messages
+  app.delete("/messages", (c) => {
+    agent.clearMessages();
+    return c.body(null, 204);
+  });
+
+  // Agent websocket
+  app.get(
+    "/task/ws",
+    upgradeWebSocket(
+      () => {
+        let firstMessageTimeoutId: number;
+        let firstMessageReceived = false;
+
+        return {
+          onOpen: (_, ws) => {
+            // Set timeout to close connection if no message is received within 6 seconds
+            firstMessageTimeoutId = setTimeout(() => {
+              if (!firstMessageReceived) {
+                if (ws.readyState === WebSocket.OPEN) {
+                  ws.close(1008, "no_message_received");
+                }
+              }
+            }, 6000); // 6 seconds timeout
+          },
+          onMessage(event, ws) {
+            if (!firstMessageReceived) {
+              firstMessageReceived = true;
+              clearTimeout(firstMessageTimeoutId); // Clear timeout as the first message has been received
+            }
+
+            let rawMessage: unknown;
+            try {
+              rawMessage = JSON.parse(event.data.toString());
+            } catch (error) {
+              if (error instanceof SyntaxError) {
+                ws.close(1003, "invalid_message");
+                return;
+              }
+              throw error;
+            }
+
+            const { success, data: message } = wsClientMessageSchema.safeParse(
+              rawMessage,
+            );
+
+            if (!success) {
+              ws.close(1003, "invalid_message");
+              return;
+            }
+
+            switch (message.action) {
+              case "startTask": {
+                const resolvedModel = message.model ??
+                  "claude-sonnet-4-5-20250929";
+
+                // Check if a task is already running
+                if (taskAbortController || taskEventSubject) {
+                  ws.close(1008, "task_already_in_progress");
+                  return;
+                }
+
+                // Create abort controller and start task
+                const abortController = taskAbortController ??=
+                  new AbortController();
+
+                const eventSubject = taskEventSubject ??= runAgentTask(
+                  agent,
+                  message.task,
+                  resolvedModel,
+                  { signal: abortController.signal },
+                );
+
+                // Subscribe to events and send them over WebSocket
+                eventSubject.subscribe({
+                  next: (taskEvent) => {
+                    serverLatestEventId = taskEvent.eventId;
+                    sendServerMessage(ws, taskEvent);
+                  },
+                  error: () => {
+                    ws.close(1011, "internal_error");
+
+                    // Clean up
+                    taskEventSubject = null;
+                    taskAbortController = null;
+                  },
+                  complete: () => {
+                    ws.close(1000, "task_complete");
+
+                    // Clean up
+                    taskEventSubject = null;
+                    taskAbortController = null;
+                  },
+                });
+                break;
+              }
+
+              case "resumeTask": {
+                // Check if a task is running
+                if (!taskEventSubject || !taskAbortController) {
+                  ws.close(1008, "task_not_running");
+                  return;
+                }
+
+                // Replay events from the task event subject
+                const events$ = replayHttpTaskEvents(
+                  taskEventSubject,
+                  serverLatestEventId,
+                  message.lastEventId,
+                );
+
+                // Subscribe to replayed events and send them over WebSocket
+                events$.subscribe({
+                  next: (taskEvent) => {
+                    sendServerMessage(ws, taskEvent);
+                  },
+                  error: () => {
+                    ws.close(1011, "internal_error");
+                  },
+                  complete: () => {
+                    sendServerMessage(ws, {
+                      type: "completed",
+                      timestamp: Date.now(),
+                    });
+                    ws.close(1000, "task_complete");
+                    // Note: Don't clean up taskEventSubject here since the original
+                    // subscription is still active. Only the startTask handler should clean up.
+                  },
+                });
+                break;
+              }
+
+              case "cancelTask": {
+                // Check if a task is running
+                if (!agent.isTaskRunning) {
+                  ws.close(1008, "task_not_running");
+                  return;
+                }
+
+                if (!taskAbortController || !taskEventSubject) {
+                  ws.close(1011, "internal_error");
+                  return;
+                }
+
+                if (!taskAbortController.signal.aborted) {
+                  taskAbortController.abort();
+                }
+
+                break;
+              }
+
+              case "approveTool": {
+                if (!toolApprovalCompletor) {
+                  ws.close(1008, "no_tool_approval_pending");
+                  return;
+                }
+
+                toolApprovalCompletor.resolve(message.approved);
+                toolApprovalCompletor = null;
+                break;
+              }
+            }
+          },
+          onClose: () => {
+            // Clean up timeout if the connection was closed before the first message was received
+            clearTimeout(firstMessageTimeoutId);
+          },
+        };
+      },
+      {
+        protocol: "zypher.v1",
+      },
+    ),
+  );
+
+  return app;
+}
+
+function runAgentTask(
+  agent: ZypherAgent,
+  taskPrompt: string,
+  model: string,
+  options?: { signal?: AbortSignal },
+): ReplaySubject<HttpTaskEvent> {
+  const zypherHttpTaskEvent$ = agent.runTask(
+    taskPrompt,
+    model,
+    [],
+    options,
+  );
+
+  // Track whether we've seen the first message event
+  let firstUserMessageEventSeen = false;
+
+  const agentHttpTaskEvent$: Observable<HttpTaskEvent> = zypherHttpTaskEvent$
+    .pipe(
+      filter((event) => {
+        // Filter out the first user message event since the client optimistically updates
+        if (!firstUserMessageEventSeen && event.type === "message") {
+          if (event.message.role === "user") {
+            firstUserMessageEventSeen = true;
+            return false; // Skip this event
+          }
+        }
+        return true;
+      }),
+      map((event): HttpTaskEvent => {
+        // Add eventId to the Zypher event
+        const eventId = HttpTaskEventId.generate();
+        return {
+          ...event,
+          eventId,
+        };
+      }),
+    );
+
+  // 30 seconds heartbeat
+  return withHttpTaskEventReplayAndHeartbeat(agentHttpTaskEvent$, 30000);
+}
+
+// Re-export for library usage
+export { type HttpTaskEvent, HttpTaskEventId } from "./task_event.ts";
+
+if (import.meta.main) {
+  const { main } = await import("./main.ts");
+  main();
+}

--- a/packages/http/schema.ts
+++ b/packages/http/schema.ts
@@ -1,0 +1,69 @@
+import z from "zod";
+import { type HttpTaskEvent, HttpTaskEventId } from "./task_event.ts";
+
+// Zod Schemas
+export const fileIdSchema = z.string().min(1, "File ID cannot be empty");
+
+// Schema for validating and transforming task event IDs - parses once into HttpTaskEventId
+export const taskEventIdSchema = z.string().transform((id, ctx) => {
+  const parsed = HttpTaskEventId.safeParse(id);
+  if (parsed === null) {
+    ctx.addIssue({
+      code: "invalid_format",
+      format: "task_<timestamp>_<sequence>",
+    });
+    return z.NEVER;
+  }
+  return parsed;
+});
+
+// WebSocket message schemas
+export const wsClientMessageSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("startTask"),
+    task: z.string(),
+    model: z.string().optional(),
+    fileAttachments: z.array(fileIdSchema).optional(),
+  }),
+  z.object({
+    action: z.literal("resumeTask"),
+    lastEventId: taskEventIdSchema.optional(),
+  }),
+  z.object({
+    action: z.literal("cancelTask"),
+  }),
+  z.object({
+    action: z.literal("approveTool"),
+    approved: z.boolean(),
+  }),
+]);
+
+// WebSocket server message schemas
+export const wsServerMessageSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("error"),
+    error: z.enum([
+      "no_message_received",
+      "invalid_message",
+      "task_already_in_progress",
+      "task_not_running",
+      "internal_error",
+      "no_tool_approval_pending",
+    ]),
+  }),
+  z.object({
+    type: z.literal("completed"),
+    timestamp: z.number(),
+  }),
+]);
+
+export type WsServerMessage = z.infer<typeof wsServerMessageSchema>;
+
+// Helper to send typed server messages
+// Uses a duck-typed interface to accept both WebSocket and WSContext
+export function sendServerMessage(
+  ws: { send: (data: string | ArrayBuffer) => void },
+  message: HttpTaskEvent | WsServerMessage,
+): void {
+  ws.send(JSON.stringify(message));
+}

--- a/packages/http/task_event.test.ts
+++ b/packages/http/task_event.test.ts
@@ -1,0 +1,161 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { HttpTaskEventId } from "./task_event.ts";
+
+Deno.test("HttpTaskEventId - constructor should parse valid ID format", () => {
+  const timestamp = 1650000000000;
+  const sequence = 5;
+  const id = HttpTaskEventId.parse(`task_${timestamp}_${sequence}`);
+
+  assertEquals(id.timestamp, timestamp);
+  assertEquals(id.sequence, sequence);
+  assertEquals(id.toString(), `task_${timestamp}_${sequence}`);
+});
+
+Deno.test("HttpTaskEventId - constructor should throw on invalid format", () => {
+  // Invalid prefix
+  assertThrows(
+    () => HttpTaskEventId.parse("invalid_1650000000000_5"),
+    Error,
+    "Invalid event ID format",
+  );
+
+  // Missing sequence
+  assertThrows(
+    () => HttpTaskEventId.parse("task_1650000000000"),
+    Error,
+    "Invalid event ID format",
+  );
+
+  // Non-numeric timestamp
+  assertThrows(
+    () => HttpTaskEventId.parse("task_timestamp_5"),
+    Error,
+    "Invalid event ID format",
+  );
+
+  // Non-numeric sequence
+  assertThrows(
+    () => HttpTaskEventId.parse("task_1650000000000_sequence"),
+    Error,
+    "Invalid event ID format",
+  );
+});
+
+Deno.test("HttpTaskEventId - generate should create unique IDs", () => {
+  const id1 = HttpTaskEventId.generate();
+  const id2 = HttpTaskEventId.generate();
+
+  // IDs should be different
+  const [timestamp1, sequence1] = parseIdParts(id1.toString());
+  const [timestamp2, sequence2] = parseIdParts(id2.toString());
+
+  // Either timestamps are different, or if they're the same, sequences should be different
+  if (timestamp1 === timestamp2) {
+    assertEquals(sequence2, sequence1 + 1);
+  } else {
+    assert(
+      timestamp2 > timestamp1,
+      "Second timestamp should be greater than first",
+    );
+  }
+});
+
+Deno.test("HttpTaskEventId - isAfter should correctly compare IDs", () => {
+  // Test with different timestamps
+  const earlier = HttpTaskEventId.parse("task_1650000000000_0");
+  const later = HttpTaskEventId.parse("task_1650000000001_0");
+
+  assertEquals(later.isAfter(earlier), true);
+  assertEquals(earlier.isAfter(later), false);
+
+  // Test with same timestamp, different sequence
+  const first = HttpTaskEventId.parse("task_1650000000000_0");
+  const second = HttpTaskEventId.parse("task_1650000000000_1");
+
+  assertEquals(second.isAfter(first), true);
+  assertEquals(first.isAfter(second), false);
+
+  // Test with same timestamp and sequence
+  const sameTime1 = HttpTaskEventId.parse("task_1650000000000_0");
+  const sameTime2 = HttpTaskEventId.parse("task_1650000000000_0");
+
+  assertEquals(sameTime1.isAfter(sameTime2), false);
+  assertEquals(sameTime2.isAfter(sameTime1), false);
+
+  // Test with higher sequence but lower timestamp
+  // Timestamp should take precedence over sequence
+  const olderHigherSequence = HttpTaskEventId.parse("task_1650000000000_5");
+  const newerLowerSequence = HttpTaskEventId.parse("task_1650000000001_0");
+
+  assertEquals(olderHigherSequence.isAfter(newerLowerSequence), false);
+  assertEquals(newerLowerSequence.isAfter(olderHigherSequence), true);
+});
+
+Deno.test("HttpTaskEventId - generateWithTimestamp should use provided timestamp", () => {
+  const timestamp = 1650000000000;
+  const id = HttpTaskEventId.generateWithTimestamp(timestamp);
+
+  assertEquals(id.timestamp, timestamp);
+});
+
+Deno.test("HttpTaskEventId - sequential generation should increment sequence", () => {
+  const timestamp = 1650000000000;
+
+  // Mock Date.now to return a consistent timestamp
+  const originalDateNow = Date.now;
+  Date.now = () => timestamp;
+
+  try {
+    // First get the current sequence by generating an ID
+    const initialId = HttpTaskEventId.generate();
+    const startingSequence = initialId.sequence;
+
+    // Now generate IDs that should increment from that starting sequence
+    const id2 = HttpTaskEventId.generate();
+    const id3 = HttpTaskEventId.generate();
+
+    assertEquals(initialId.timestamp, timestamp);
+    assertEquals(id2.timestamp, timestamp);
+    assertEquals(id3.timestamp, timestamp);
+
+    // Verify they increment properly regardless of starting point
+    assertEquals(id2.sequence, startingSequence + 1);
+    assertEquals(id3.sequence, startingSequence + 2);
+  } finally {
+    // Restore original Date.now
+    Date.now = originalDateNow;
+  }
+});
+
+Deno.test("HttpTaskEventId - reset sequence when timestamp changes", () => {
+  // First generate with timestamp1 and get the sequence
+  const timestamp1 = 1650000000000;
+  const id1 = HttpTaskEventId.generateWithTimestamp(timestamp1);
+  const id2 = HttpTaskEventId.generateWithTimestamp(timestamp1);
+
+  // Verify sequence increased
+  assertEquals(id2.sequence, id1.sequence + 1);
+
+  // Now generate with a different timestamp
+  const timestamp2 = 1650000000001;
+  const newId = HttpTaskEventId.generateWithTimestamp(timestamp2);
+
+  // Sequence should be reset to 0
+  assertEquals(newId.sequence, 0);
+});
+
+// Helper function to parse ID parts
+function parseIdParts(id: string): [number, number] {
+  const match = id.match(/^task_(\d+)_(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid ID format: ${id}`);
+  }
+  return [parseInt(match[1], 10), parseInt(match[2], 10)];
+}
+
+// Helper assert function
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/packages/http/task_event.ts
+++ b/packages/http/task_event.ts
@@ -1,0 +1,302 @@
+import type { TaskEvent as AgentTaskEvent } from "@zypher/agent";
+import { filter, Observable, ReplaySubject } from "rxjs";
+
+/**
+ * Event types for task execution events using discriminated union types
+ */
+export type HttpTaskEvent =
+  & (AgentTaskEvent | HeartbeatEvent)
+  & {
+    eventId: HttpTaskEventId;
+  };
+
+/**
+ * Heartbeat event data
+ */
+export interface HeartbeatEvent {
+  type: "heartbeat";
+  timestamp: number;
+}
+
+/**
+ * Represents a unique identifier for task events with timestamp and sequence components.
+ * Format: task_<timestamp>_<sequence>
+ */
+export class HttpTaskEventId {
+  // Static state to maintain uniqueness across instances
+  static #lastTimestamp: number = 0;
+  static #currentSequence: number = 0;
+  #timestamp: number;
+  #sequence: number;
+  #raw: string;
+
+  /**
+   * Private constructor - use HttpTaskEventId.parse() or HttpTaskEventId.generate() instead
+   * @param rawId The string representation of the ID in format task_<timestamp>_<sequence>
+   * @param timestamp The timestamp component
+   * @param sequence The sequence component
+   */
+  private constructor(rawId: string, timestamp: number, sequence: number) {
+    this.#raw = rawId;
+    this.#timestamp = timestamp;
+    this.#sequence = sequence;
+  }
+
+  /**
+   * Parses a string into a HttpTaskEventId
+   * @param rawId The string representation of the ID in format task_<timestamp>_<sequence>
+   * @throws Error if the format is invalid
+   * @returns A HttpTaskEventId instance
+   */
+  static parse(rawId: string): HttpTaskEventId {
+    const match = rawId.match(/^task_(\d+)_(\d+)$/);
+
+    if (!match) {
+      throw new Error(
+        `Invalid event ID format: ${rawId}. Expected format: task_<timestamp>_<sequence>`,
+      );
+    }
+
+    const timestamp = parseInt(match[1], 10);
+    const sequence = parseInt(match[2], 10);
+    return new HttpTaskEventId(rawId, timestamp, sequence);
+  }
+
+  /**
+   * Safely parses a string into a HttpTaskEventId without throwing exceptions
+   * @param rawId The string representation of the ID
+   * @returns The HttpTaskEventId if valid, null otherwise
+   */
+  static safeParse(rawId: string): HttpTaskEventId | null {
+    const match = rawId.match(/^task_(\d+)_(\d+)$/);
+    if (!match) {
+      return null;
+    }
+
+    const timestamp = parseInt(match[1], 10);
+    const sequence = parseInt(match[2], 10);
+    return new HttpTaskEventId(rawId, timestamp, sequence);
+  }
+
+  /**
+   * Creates a new HttpTaskEventId with the current timestamp and an appropriate sequence number
+   */
+  static generate(): HttpTaskEventId {
+    return HttpTaskEventId.generateWithTimestamp(Date.now());
+  }
+
+  /**
+   * Creates a new HttpTaskEventId with the specified timestamp and an appropriate sequence number
+   * This is primarily useful for testing or when you need to create an ID with a specific timestamp
+   */
+  static generateWithTimestamp(timestamp: number): HttpTaskEventId {
+    // Keep track of last timestamp and sequence for uniqueness
+    if (timestamp === HttpTaskEventId.#lastTimestamp) {
+      HttpTaskEventId.#currentSequence++;
+    } else {
+      HttpTaskEventId.#lastTimestamp = timestamp;
+      HttpTaskEventId.#currentSequence = 0;
+    }
+
+    const raw = `task_${timestamp}_${HttpTaskEventId.#currentSequence}`;
+    return new HttpTaskEventId(
+      raw,
+      timestamp,
+      HttpTaskEventId.#currentSequence,
+    );
+  }
+
+  /**
+   * Returns the raw string representation of the ID
+   */
+  toString(): string {
+    return this.#raw;
+  }
+
+  /**
+   * Custom JSON serialization - returns the string representation
+   */
+  toJSON(): string {
+    return this.#raw;
+  }
+
+  /**
+   * Checks if this event ID is chronologically after another event ID
+   * @param other The other HttpTaskEventId to compare with
+   * @returns true if this event occurred after the other event
+   */
+  isAfter(other: HttpTaskEventId): boolean {
+    if (this.#timestamp > other.#timestamp) {
+      return true;
+    }
+
+    return this.#timestamp === other.#timestamp &&
+      this.#sequence > other.#sequence;
+  }
+
+  /**
+   * Gets the timestamp component of the ID
+   */
+  get timestamp(): number {
+    return this.#timestamp;
+  }
+
+  /**
+   * Gets the sequence component of the ID
+   */
+  get sequence(): number {
+    return this.#sequence;
+  }
+}
+
+/**
+ * Adds heartbeat events to an Observable during periods of inactivity
+ * @template T The type of events in the source Observable
+ * @param source The source Observable
+ * @param heartbeatInterval The interval in milliseconds to wait before emitting a heartbeat
+ * @param createHeartbeatFn Function to create a heartbeat event
+ * @returns An Observable that includes the original events plus heartbeat events
+ */
+export function withHeartbeat<T>(
+  source: Observable<T>,
+  heartbeatInterval: number,
+  createHeartbeatFn: () => T,
+): Observable<T> {
+  return new Observable<T>((observer) => {
+    let heartbeatTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    // Function to schedule the next heartbeat
+    const scheduleHeartbeat = () => {
+      // Clear any existing timeout
+      if (heartbeatTimeout !== null) {
+        clearTimeout(heartbeatTimeout);
+      }
+
+      // Schedule a new heartbeat
+      heartbeatTimeout = setTimeout(() => {
+        const heartbeatEvent = createHeartbeatFn();
+        observer.next(heartbeatEvent);
+
+        // Schedule the next heartbeat
+        scheduleHeartbeat();
+      }, heartbeatInterval);
+    };
+
+    // Start the heartbeat scheduling
+    scheduleHeartbeat();
+
+    // Subscribe to the source and forward events
+    const subscription = source.subscribe({
+      next: (event) => {
+        // Forward the event
+        observer.next(event);
+
+        // Reset the heartbeat timer
+        scheduleHeartbeat();
+      },
+      error: (err) => {
+        if (heartbeatTimeout !== null) {
+          clearTimeout(heartbeatTimeout);
+        }
+        observer.error(err);
+      },
+      complete: () => {
+        if (heartbeatTimeout !== null) {
+          clearTimeout(heartbeatTimeout);
+        }
+        observer.complete();
+      },
+    });
+
+    // Return cleanup function
+    return () => {
+      subscription.unsubscribe();
+      if (heartbeatTimeout !== null) {
+        clearTimeout(heartbeatTimeout);
+      }
+    };
+  });
+}
+
+/**
+ * Converts an Observable to a ReplaySubject that will replay all events to new subscribers
+ * @template T The type of events in the source Observable
+ * @param source The source Observable
+ * @returns A ReplaySubject that replays all events to new subscribers
+ */
+export function withReplay<T>(source: Observable<T>): ReplaySubject<T> {
+  const subject = new ReplaySubject<T>();
+
+  // Subscribe the subject directly to the source
+  source.subscribe(subject);
+
+  return subject;
+}
+
+/**
+ * Creates a task heartbeat event
+ * @returns A heartbeat HttpTaskEvent
+ */
+export function createTaskHeartbeat(): HttpTaskEvent {
+  return {
+    type: "heartbeat",
+    timestamp: Date.now(),
+    eventId: HttpTaskEventId.generate(),
+  };
+}
+
+/**
+ * Creates a ReplaySubject from an Observable that emits heartbeat events during periods of inactivity
+ * @param source The source Observable of HttpTaskEvent objects
+ * @param heartbeatInterval The interval in milliseconds to wait before emitting a heartbeat
+ * @returns A ReplaySubject that replays all events including added heartbeats
+ */
+export function withHttpTaskEventReplayAndHeartbeat(
+  source: Observable<HttpTaskEvent>,
+  heartbeatInterval: number,
+): ReplaySubject<HttpTaskEvent> {
+  // First add heartbeat events, then convert to a ReplaySubject
+  return withReplay(
+    withHeartbeat(source, heartbeatInterval, createTaskHeartbeat),
+  );
+}
+
+/**
+ * Filters events from a ReplaySubject to replay only events that occurred after
+ * a specified event ID (if provided) and filters out stale pending approval events.
+ *
+ * @param source The ReplaySubject containing the events to replay
+ * @param serverLatestEventId The ID of the most recent event produced by the server at the moment
+ * when this function is called. This is used to filter out stale pending approval events.
+ * Stale pending approval events are those that occurred after the clientLastEventId but before the serverLatestEventId.
+ * @param clientLastEventId The ID of the last event that was received by the client
+ * @returns An Observable that emits only events that occurred after the specified event ID
+ */
+export function replayHttpTaskEvents(
+  source: ReplaySubject<HttpTaskEvent>,
+  serverLatestEventId?: HttpTaskEventId,
+  clientLastEventId?: HttpTaskEventId,
+): Observable<HttpTaskEvent> {
+  return source
+    .asObservable()
+    .pipe(
+      // First filter: only include events after clientLastEventId (if provided)
+      filter((event) =>
+        clientLastEventId ? event.eventId.isAfter(clientLastEventId) : true
+      ),
+      // Second filter: filter out stale pending approval events
+      filter((event) => {
+        // Only apply this filter to tool_approval_pending events when serverLatestEventId is provided
+        if (serverLatestEventId && event.type === "tool_use_pending_approval") {
+          // Create HttpTaskEventId objects for comparison
+          const eventId = event.eventId;
+
+          // Keep the event if it's newer than or equal to the server's latest event
+          // (i.e., filter out stale pending approval events that happened before the server's latest event)
+          return !serverLatestEventId.isAfter(eventId);
+        }
+        // Keep all other event types
+        return true;
+      }),
+    );
+}


### PR DESCRIPTION
## Summary

Add `@zypher/http` package that exposes Zypher agent as an HTTP API server.

- Framework-agnostic Hono-based handler (works with Deno.serve, Hono, or any web framework)
- WebSocket endpoint `/task/ws` with `zypher.v1` protocol for real-time task streaming
- REST endpoints: `/health`, `/messages`
- Runnable as standalone server `deno run -A jsr:@zypher/http`
- Event replay/resume and heartbeat support for connection resilience

## Usage

**As library:**
```ts
import { createZypherHandler } from "@zypher/http";

const app = createZypherHandler({ agent });
Deno.serve(app.fetch);
```

**As standalone server:**
```bash
deno run -A jsr:@zypher/http -k YOUR_API_KEY -p 8080
```