### PR TITLE
chore(agent): bump version to 0.9.0

### DIFF
--- a/packages/agent/deno.json
+++ b/packages/agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zypher/agent",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",


### PR DESCRIPTION
## Summary
- Bumps @zypher/agent package version from 0.8.1 to 0.9.0