### PR TITLE
fix(ui): replace JSX with createElement to fix non-Deno consumers

### DIFF
--- a/packages/ui/agent_context.ts
+++ b/packages/ui/agent_context.ts
@@ -1,4 +1,4 @@
-import { createContext, type JSX, type ReactNode, use } from "react";
+import { createContext, createElement, type ReactNode, use } from "react";
 import type { TaskApiClient } from "./task_api_client.ts";
 import { useAgent, type UseAgentReturn } from "./use_agent.ts";
 
@@ -14,10 +14,10 @@ export interface AgentProviderOptions {
 export function AgentProvider({
   children,
   client,
-}: AgentProviderOptions): JSX.Element {
+}: AgentProviderOptions): ReactNode {
   const agentState = useAgent({ client });
 
-  return <AgentContext value={agentState}>{children}</AgentContext>;
+  return createElement(AgentContext, { value: agentState }, children);
 }
 
 /** Hook to access agent state from within an AgentProvider. */

--- a/packages/ui/deno.json
+++ b/packages/ui/deno.json
@@ -24,9 +24,5 @@
     "rules": {
       "tags": ["react"]
     }
-  },
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "react"
   }
 }

--- a/packages/ui/mod.ts
+++ b/packages/ui/mod.ts
@@ -39,8 +39,8 @@ export type {
 } from "./use_mcp_servers.ts";
 
 // Agent context provider and hook
-export { AgentProvider, useAgentContext } from "./agent_context.tsx";
-export type { AgentProviderOptions } from "./agent_context.tsx";
+export { AgentProvider, useAgentContext } from "./agent_context.ts";
+export type { AgentProviderOptions } from "./agent_context.ts";
 
 // Agent hook and types
 export {


### PR DESCRIPTION
## Summary
- Converted `agent_context.tsx` to `agent_context.ts`, replacing JSX with `createElement()` call
- Removed JSX compiler options from `packages/ui/deno.json` since no `.tsx` files remain
- Updated import paths in `mod.ts`

This fixes the issue where JSR rewrites bare `"react"` imports to `npm:react@^19.2.4` in published `.tsx` files, causing TypeScript errors for non-Deno consumers (bun, node):

```
Cannot find module 'npm:react@^19.2.4' or its corresponding type declarations.
```

## Test plan
- [x] `deno check packages/ui/mod.ts` passes
- [x] `deno lint packages/ui/agent_context.ts` passes
- [ ] Verify consuming project (bun/node) can import `@zypher/ui` without TSC errors after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)