### PR TITLE
feat(llm): add MiniMax as an OpenAI-compatible provider

### DIFF
--- a/packages/agent/llm/model.ts
+++ b/packages/agent/llm/model.ts
@@ -30,6 +30,7 @@ const MODEL_BASE_URLS: Record<string, string> = {
   deepseek: "https://api.deepseek.com/v1",
   qwen: "https://dashscope.aliyuncs.com/compatible-mode/v1",
   grok: "https://api.x.ai/v1",
+  minimax: "https://api.minimax.io/v1",
 };
 
 /**
@@ -90,6 +91,7 @@ function inferBaseUrl(model: string): string | undefined {
  * - deepseek* → DeepSeek (api.deepseek.com)
  * - qwen* → Alibaba DashScope (dashscope.aliyuncs.com)
  * - grok* → xAI (api.x.ai)
+ * - minimax* → MiniMax (api.minimax.io)
  *
  * @example
  * ```typescript
@@ -104,6 +106,7 @@ function inferBaseUrl(model: string): string | undefined {
  * const provider = createModelProvider("deepseek-chat");              // → openai (with DeepSeek base URL)
  * const provider = createModelProvider("qwen-plus");                  // → openai (with DashScope base URL)
  * const provider = createModelProvider("grok-2");                     // → openai (with xAI base URL)
+ * const provider = createModelProvider("MiniMax-M3");                  // → openai (with MiniMax base URL)
  * const provider = createModelProvider("llama-3.3-70b");              // → openai (no default URL, self-hosted)
  *
  * // With options (API key optional - falls back to env vars)


### PR DESCRIPTION
Reason: The model factory did not recognize MiniMax, so its API base URL was never inferred for MiniMax model IDs.

## What changed

MiniMax speaks the OpenAI-compatible protocol, so it is registered the same way the other OpenAI-compatible providers already are in `packages/agent/llm/model.ts`:

- Added a `minimax` entry to the `MODEL_BASE_URLS` registry pointing at the global API base URL (`https://api.minimax.io/v1`). `createModelProvider` now auto-infers this base URL for `MiniMax-*` model IDs (e.g. `MiniMax-M3`, `MiniMax-M2.7`) and routes them through the existing OpenAI-compatible provider.
- Updated the `createModelProvider` doc comment (the list of auto-inferred base URLs and the usage examples) to document the new entry.

Regional selection is preserved through the existing mechanism: the global endpoint is the inferred default, and callers can still point at a different regional endpoint via the existing `baseUrl` option / CLI `--base-url` flag.

## Checks

- `deno fmt --check packages/agent/llm/model.ts` — passed
- `deno lint packages/agent/llm/model.ts` — passed

`deno check` surfaces one pre-existing `TS2322` type error in `packages/agent/zypher_agent.ts` that also reproduces on an unmodified checkout of the base branch; it is unrelated to this change, which only adds a string entry and doc comments.
