### PR TITLE
feat(llm): add MiniMax regional endpoint presets

### DIFF
--- a/packages/agent/llm/model.test.ts
+++ b/packages/agent/llm/model.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "@std/assert";
+import { createModelProvider } from "./model.ts";
+import { PROVIDER_PRESETS } from "./provider_presets.ts";
+
+Deno.test("createModelProvider selects MiniMax protocol presets", () => {
+  const cases = [
+    ["minimax", "openai", "https://api.minimax.io/v1"],
+    ["minimax-cn", "openai", "https://api.minimaxi.com/v1"],
+    [
+      "minimax-anthropic",
+      "anthropic",
+      "https://api.minimax.io/anthropic",
+    ],
+    [
+      "minimax-cn-anthropic",
+      "anthropic",
+      "https://api.minimaxi.com/anthropic",
+    ],
+  ] as const;
+
+  for (const [presetName, providerName, baseUrl] of cases) {
+    assertEquals(PROVIDER_PRESETS[presetName], {
+      provider: providerName,
+      baseUrl,
+    });
+
+    const provider = createModelProvider(`${presetName}/MiniMax-M3`, {
+      apiKey: "test-key",
+    });
+    assertEquals(provider.info.name, providerName);
+    assertEquals(provider.modelId, "MiniMax-M3");
+  }
+});

--- a/packages/agent/llm/model.ts
+++ b/packages/agent/llm/model.ts
@@ -7,6 +7,7 @@ import {
   OpenAIModelProvider,
   type OpenAIModelProviderOptions,
 } from "./openai.ts";
+import { PROVIDER_PRESETS } from "./provider_presets.ts";
 
 /**
  * Default models for each provider.
@@ -82,6 +83,12 @@ function inferBaseUrl(model: string): string | undefined {
  * - Explicit: "provider/model-id" (e.g., "anthropic/claude-sonnet-4-5-20250929")
  * - Auto-inferred: "model-id" (e.g., "claude-sonnet-4-5-20250929" → anthropic)
  *
+ * MiniMax explicit providers select a protocol and region:
+ * - `minimax` → global OpenAI-compatible endpoint
+ * - `minimax-cn` → China OpenAI-compatible endpoint
+ * - `minimax-anthropic` → global Anthropic-compatible endpoint
+ * - `minimax-cn-anthropic` → China Anthropic-compatible endpoint
+ *
  * Provider is auto-inferred from well-known model name patterns:
  * - Anthropic: claude*, sonnet*, haiku*, opus*
  * - OpenAI (default): Everything else, including OpenAI-compatible models
@@ -98,6 +105,9 @@ function inferBaseUrl(model: string): string | undefined {
  * // Explicit provider/model format
  * const provider = createModelProvider("anthropic/claude-sonnet-4-5-20250929");
  * const provider = createModelProvider("openai/gpt-5.2");
+ * const provider = createModelProvider("minimax-cn/MiniMax-M3");
+ * const provider = createModelProvider("minimax-anthropic/MiniMax-M3");
+ * const provider = createModelProvider("minimax-cn-anthropic/MiniMax-M3");
  *
  * // Auto-inferred provider from model name
  * const provider = createModelProvider("claude-sonnet-4-5-20250929"); // → anthropic
@@ -146,10 +156,13 @@ export function createModelProvider(
   }
 
   const providerKey = provider.toLowerCase();
+  const providerPreset = PROVIDER_PRESETS[providerKey];
+  const resolvedProvider: string = providerPreset?.provider ?? providerKey;
   // Use explicit baseUrl if provided, otherwise infer from model name
-  const baseUrl = options.baseUrl ?? inferBaseUrl(modelId);
+  const baseUrl = options.baseUrl ?? providerPreset?.baseUrl ??
+    inferBaseUrl(modelId);
 
-  switch (providerKey) {
+  switch (resolvedProvider) {
     case "anthropic":
       return new AnthropicModelProvider({
         model: modelId,

--- a/packages/agent/llm/provider_presets.ts
+++ b/packages/agent/llm/provider_presets.ts
@@ -1,0 +1,26 @@
+export type ProviderPreset = {
+  provider: "anthropic" | "openai";
+  baseUrl: string;
+};
+
+/**
+ * Explicit provider presets for MiniMax protocol and region selection.
+ */
+export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
+  minimax: {
+    provider: "openai",
+    baseUrl: "https://api.minimax.io/v1",
+  },
+  "minimax-cn": {
+    provider: "openai",
+    baseUrl: "https://api.minimaxi.com/v1",
+  },
+  "minimax-anthropic": {
+    provider: "anthropic",
+    baseUrl: "https://api.minimax.io/anthropic",
+  },
+  "minimax-cn-anthropic": {
+    provider: "anthropic",
+    baseUrl: "https://api.minimaxi.com/anthropic",
+  },
+};


### PR DESCRIPTION
Reason: The provider factory only inferred the global MiniMax OpenAI-compatible endpoint, leaving the China OpenAI-compatible and both Anthropic-compatible regional endpoints without explicit selection.

## What changed

- Added explicit MiniMax provider presets for global and China OpenAI-compatible endpoints.
- Added explicit MiniMax provider presets for global and China Anthropic-compatible endpoints.
- Preserved an explicit `baseUrl` override and the existing global default for bare model IDs.
- Added a focused test covering each preset's protocol, endpoint, and model routing.

## Checks

- `deno test -A packages/agent/llm/model.test.ts`
- `deno fmt --check packages/agent/llm/model.ts packages/agent/llm/model.test.ts packages/agent/llm/provider_presets.ts`
- `deno lint packages/agent/llm/model.ts packages/agent/llm/model.test.ts packages/agent/llm/provider_presets.ts`
- `deno check packages/agent/llm/model.ts packages/agent/llm/model.test.ts packages/agent/llm/provider_presets.ts`
