### PR TITLE
fix(ui): reset agentSocketRef on task completion

### DIFF
--- a/packages/agent/tools/fs/edit_file_tool.ts
+++ b/packages/agent/tools/fs/edit_file_tool.ts
@@ -144,7 +144,8 @@ Action types:
             await Deno.writeTextFile(target, output, {
               signal: options?.signal,
             });
-            return `Replaced ${occurrences} occurrences`;
+            const replacedCount = params.replaceAll ? occurrences : 1;
+            return `Replaced ${replacedCount} occurrence${replacedCount > 1 ? "s" : ""}`;
           } else {
             return "No occurrences found to replace";
           }

--- a/packages/agent/zypher_agent.ts
+++ b/packages/agent/zypher_agent.ts
@@ -364,7 +364,7 @@ export class ZypherAgent {
       : timeoutController.signal;
 
     // Set up task timeout if enabled
-    let timeoutId: number | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     if (this.#config.taskTimeoutMs > 0) {
       timeoutId = setTimeout(
         () => timeoutController.abort(),

--- a/packages/http/handler.ts
+++ b/packages/http/handler.ts
@@ -170,7 +170,7 @@ export function createZypherHandler(options: ZypherHandlerOptions): Hono {
       "/task/ws",
       upgradeWebSocket(
         () => {
-          let firstMessageTimeoutId: number;
+          let firstMessageTimeoutId: ReturnType<typeof setTimeout>;
           let firstMessageReceived = false;
 
           return {

--- a/packages/ui/use_agent.ts
+++ b/packages/ui/use_agent.ts
@@ -373,6 +373,7 @@ export function useAgent(options: UseAgentOptions): UseAgentReturn {
       } finally {
         setIsTaskRunning(false);
         setStreamingMessages([]);
+        agentSocketRef.current = null;
       }
     },
     [mutateMessages, onEvent],


### PR DESCRIPTION
In useAgent (packages/ui/use_agent.ts), agentSocketRef.current was never reset to null when a task finished in handleTaskEvents. As a result, subsequent calls to resumeTask returned early believing an active socket connection still existed. Also fixed replace_str count reporting when replaceAll is false, and normalized timeoutId typing for cross-environment compatibility.